### PR TITLE
thecolorsthatheal.com relaunch

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "util": "^0.12.4"
   },
   "scripts": {
-    "start": "GENERATE_SOURCEMAP=false react-scripts start",
+    "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^10.1.0",
+    "cross-env": "^7.0.3",
     "typechain": "^8.1.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,9 @@ function App() {
     <AppProviders>
       <Router>
         <Routes>
-          <Route index element={<HomePage />} />
-          <Route path="projects" element={<ProjectsPage />} />
-          <Route path="project/:projectId" element={<ProjectPage />} />
+          <Route index element={<ProjectPage />} />
           <Route path="token/:id" element={<TokenPage />} />
+          <Route path="about" element={<HomePage />} />
         </Routes>
       </Router>
 

--- a/src/components/ProjectOverview.tsx
+++ b/src/components/ProjectOverview.tsx
@@ -58,11 +58,6 @@ const ProjectOverview = ({ project }:Props) => {
               startTime={project.minterConfiguration?.startTime}
             />
 
-            <Link href={`/project/${project.projectId}`} sx={{ display: 'block', marginTop: 3 }} underline="hover">
-              <Typography variant="h4">
-                { project.name }
-              </Typography>
-            </Link>
             <Typography variant="h6">
               { project.artistName }
             </Typography>

--- a/src/components/ProjectSummary.tsx
+++ b/src/components/ProjectSummary.tsx
@@ -40,7 +40,7 @@ const ProjectSummary = ({
         />
       </Box>
       <Box mt={2}>
-        <Link href={`/project/${project.projectId}`} underline="hover" sx={{ marginTop: 1, fontSize: 32 }}>
+        <Link href={`/`} underline="hover" sx={{ marginTop: 1, fontSize: 32 }}>
           { project.name }
         </Link>
         <Typography variant="h6" mb={2}>

--- a/src/components/TokenDetails.tsx
+++ b/src/components/TokenDetails.tsx
@@ -50,9 +50,6 @@ const TokenDetails = ({ id }: Props) => {
         <Link href="/" underline="hover" sx={{ color: '#666' }}>
           Home
         </Link>
-        <Link href={`/project/${token.project.projectId}`} underline="hover" sx={{ color: '#666' }}>
-          { token.project.name }
-        </Link>
         <Typography>
           #{ token.invocation }
         </Typography>

--- a/src/components/pages/ProjectPage.tsx
+++ b/src/components/pages/ProjectPage.tsx
@@ -7,8 +7,7 @@ import { coreContractAddress } from 'config';
 import TOBOProject from 'components/tobo/TOBOProject';
 
 const ProjectPage = () => {
-  const { projectId } = useParams();
-
+  const { projectId = 0} = useParams();
   return (
     <TOBOPage>
       {/* {

--- a/src/components/tobo/TOBOFooter.tsx
+++ b/src/components/tobo/TOBOFooter.tsx
@@ -1,11 +1,20 @@
 import "./toboFooter.css";
+import { useNavigate } from "react-router-dom";
 
 /* TOBOFooter */
 
 const TOBOFooter = () => {
+  
+const navigate = useNavigate();
+
+const headingClick = () => {
+  navigate(`/about`);
+};
+
   return (
     <footer>
-      <img
+      
+      <img onClick={headingClick}
         src="/img/tobo/logo-footer.svg"
         alt="TURNOUT FOR BURNOUT"
         id="footer-logo"
@@ -40,9 +49,9 @@ const TOBOFooter = () => {
         <div id="footerDetailsDisclaimer">
           <h6>About</h6>
           <p>
-            Turnout for Burnout is a fundraising effort dedicated to finding
-            solutions for burnout and combatting the resulting symptoms in local
-            healthcare worker populations.
+            <em>The Colors That Heal</em> is a project in support of "Turnout for Burnout," a fundraising effort dedicated to finding
+            solutions for burnout and combatting the resulting symptoms in local healthcare worker populations. To discover more ways 
+            to support the "Turnout for Burnout" campaign, <a href="/about">click here.</a>
           </p>
           <span>(c) 2022</span>
         </div>

--- a/src/components/tobo/TOBOHeader.tsx
+++ b/src/components/tobo/TOBOHeader.tsx
@@ -24,7 +24,7 @@ const TOBOHeader = () => {
 */
   return (
     <header>
-      <h3 onClick={logoClick} className="masthead">The Colors That Heal</h3>
+      <h3 onClick={logoClick} className="masthead">The <span style={{color:"#7ac4e2"}}>Colors</span> That Heal</h3>
       <ConnectWallet className={!isActive ? "hide" : ""} />
     </header>
   );

--- a/src/components/tobo/TOBOHeader.tsx
+++ b/src/components/tobo/TOBOHeader.tsx
@@ -2,6 +2,7 @@ import ConnectWallet from "../ConnectWallet";
 import { useNavigate } from "react-router-dom";
 import "./toboHeader.css";
 import { useWeb3React } from "@web3-react/core";
+import Typography from '@mui/material/Typography';
 
 /* TOBOHeader */
 
@@ -12,10 +13,7 @@ const TOBOHeader = () => {
   const logoClick = () => {
     navigate("/");
   };
-
-  return (
-    <header>
-      <h1 onClick={logoClick}>
+/*<h1 onClick={logoClick}>
         <img src="/img/tobo/logo.svg" alt="TURNOUT FOR BURNOUT" id="toboLogo" />
         <img
           src="/img/tobo/logo-footer.svg"
@@ -23,7 +21,10 @@ const TOBOHeader = () => {
           id="toboMobileLogo"
         />
       </h1>
-
+*/
+  return (
+    <header>
+      <h3 onClick={logoClick} className="masthead">The Colors That Heal</h3>
       <ConnectWallet className={!isActive ? "hide" : ""} />
     </header>
   );

--- a/src/components/tobo/TOBOHeader.tsx
+++ b/src/components/tobo/TOBOHeader.tsx
@@ -2,7 +2,6 @@ import ConnectWallet from "../ConnectWallet";
 import { useNavigate } from "react-router-dom";
 import "./toboHeader.css";
 import { useWeb3React } from "@web3-react/core";
-import Typography from '@mui/material/Typography';
 
 /* TOBOHeader */
 
@@ -13,15 +12,7 @@ const TOBOHeader = () => {
   const logoClick = () => {
     navigate("/");
   };
-/*<h1 onClick={logoClick}>
-        <img src="/img/tobo/logo.svg" alt="TURNOUT FOR BURNOUT" id="toboLogo" />
-        <img
-          src="/img/tobo/logo-footer.svg"
-          alt="TURNOUT FOR BURNOUT"
-          id="toboMobileLogo"
-        />
-      </h1>
-*/
+
   return (
     <header>
       <h3 onClick={logoClick} className="masthead">The <span style={{color:"#7ac4e2"}}>Colors</span> That Heal</h3>

--- a/src/components/tobo/TOBOHeader.tsx
+++ b/src/components/tobo/TOBOHeader.tsx
@@ -25,7 +25,7 @@ const TOBOHeader = () => {
   return (
     <header>
       <h3 onClick={logoClick} className="masthead">The <span style={{color:"#7ac4e2"}}>Colors</span> That Heal</h3>
-      <ConnectWallet className={!isActive ? "hide" : ""} />
+      <ConnectWallet />
     </header>
   );
 };

--- a/src/components/tobo/TOBOProject.tsx
+++ b/src/components/tobo/TOBOProject.tsx
@@ -51,9 +51,8 @@ function ProjectDetails(props: { id: string }) {
       </div>
 
       <div id="projectDetailsInfo">
-        <h3>{project && project.name}</h3>
         <div className="clear"></div>
-        <h4>{project && project.artistName}</h4>
+        <h4>by {project && project.artistName}</h4>
         <h5>
           <span>{project && project.invocations}</span> of{" "}
           <span>{project && project.maxInvocations}</span> generated

--- a/src/components/tobo/TOBOProjects.tsx
+++ b/src/components/tobo/TOBOProjects.tsx
@@ -18,11 +18,11 @@ const TOBOProject = (props: { project: Project }) => {
   const navigate = useNavigate();
 
   const ctaClick = () => {
-    navigate(`/project/${props.project.projectId}`);
+    navigate(`/`);
   };
 
   return (
-    <a className="toboProject" href={`/project/${props.project.projectId}`}>
+    <a className="toboProject" href={`/`}>
       <TOBOMint invocation="0" live />
       <div className="projectCircle"></div>
 

--- a/src/components/tobo/TOBOSplash.tsx
+++ b/src/components/tobo/TOBOSplash.tsx
@@ -9,7 +9,7 @@ import "./toboSplash.css";
 function SplashModule4() {
   const navigate = useNavigate();
   const mintClick = () => {
-    navigate("/project/0");
+    navigate("/");
   };
   return (
     <div className="toboModule" id="toboSplashModule4">
@@ -90,7 +90,7 @@ function SplashModule2() {
   const navigate = useNavigate();
 
   const mintClick = () => {
-    navigate("/project/0");
+    navigate("/");
   };
 
   return (
@@ -143,7 +143,7 @@ function SplashModule1() {
   };
 
   const mintClick = () => {
-    navigate("/project/0");
+    navigate("/");
   };
 
   return (

--- a/src/components/tobo/TOBOToken.tsx
+++ b/src/components/tobo/TOBOToken.tsx
@@ -131,7 +131,7 @@ function TokenPreview(props: { token: any; invocation: string }) {
       <h4>
         <div>by {props.token.project.artistName}</div>
         <br />
-        <a onClick={headingClick}><em>VIEW PROJECT</em></a>
+        <a onClick={headingClick} style={{cursor:'pointer'}}><em>VIEW PROJECT</em></a>
       </h4>
     </div>
   );

--- a/src/components/tobo/TOBOToken.tsx
+++ b/src/components/tobo/TOBOToken.tsx
@@ -121,19 +121,18 @@ function TokenPreview(props: { token: any; invocation: string }) {
   const navigate = useNavigate();
 
   const headingClick = () => {
-    navigate(`/project/0`);
+    navigate(`/`);
   };
 
   return (
     <div id="toboTokenPreview">
       <TOBOMint invocation={props.invocation} live={true} />
       {/*<img src={ `${ mediaUrl }/thumb/${ props.invocation }.png` } alt="" />*/}
-      <h3 onClick={headingClick}>
-        {props.token.project.name}
-        <span>by {props.token.project.artistName}</span>
+      <h4>
+        <div>by {props.token.project.artistName}</div>
         <br />
-        <i>VIEW PROJECT</i>
-      </h3>
+        <a onClick={headingClick}><em>VIEW PROJECT</em></a>
+      </h4>
     </div>
   );
 }

--- a/src/components/tobo/toboFooter.css
+++ b/src/components/tobo/toboFooter.css
@@ -12,6 +12,7 @@ img#footer-logo {
   width: 26.7%;
   margin-left: 4.3%;
   margin-top: 47px;
+  cursor: pointer;
 }
 
 #footerDetails {

--- a/src/components/tobo/toboHeader.css
+++ b/src/components/tobo/toboHeader.css
@@ -3,7 +3,7 @@
 #toboPage header {
   position: fixed;
   width: 100%;
-  height: 80px;
+  height: 60px;
   top: 0;
 }
 
@@ -62,7 +62,7 @@ img#toboMobileLogo {
   }
 
   #toboPage  header h3 {
-    padding-top:60px;
+    font-size: 18px !important;
   }
 
   #toboPage header button {
@@ -74,4 +74,13 @@ img#toboMobileLogo {
     right: 10px;
     top: 11px;
   }
+}
+
+@media only screen and (max-width: 300px) {
+  
+  #toboPage  header h3 {
+    font-size: 18px !important;
+    padding-top:60px;
+  }
+
 }

--- a/src/components/tobo/toboHeader.css
+++ b/src/components/tobo/toboHeader.css
@@ -7,9 +7,8 @@
   top: 0;
 }
 
-#toboPage header h1 {
+#toboPage header h3 {
   cursor: pointer;
-  width: max-content;
   margin: auto;
 }
 

--- a/src/components/tobo/toboHeader.css
+++ b/src/components/tobo/toboHeader.css
@@ -48,23 +48,21 @@ img#toboMobileLogo {
   display: none;
 }
 
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 553px) {
   #toboPage header {
     height: 60px;
   }
 
   #toboPage header button {
-    display: none;
+    /*display: none;*/
   }
 
   img#toboLogo {
     display: none;
   }
 
-  img#toboMobileLogo {
-    display: inline;
-    height: 60px;
-    padding: 4px;
+  #toboPage  header h3 {
+    padding-top:60px;
   }
 
   #toboPage header button {

--- a/src/components/tobo/toboProjects.css
+++ b/src/components/tobo/toboProjects.css
@@ -51,6 +51,7 @@ a#projectsArtBlocks img#artBlocksArrow {
 @media only screen and (max-width: 767px) {
   #toboProjects {
     padding-bottom: 94px;
+    overflow: hidden;
   }
 
   #toboProjects h3 {

--- a/src/components/tobo/toboToken.css
+++ b/src/components/tobo/toboToken.css
@@ -48,8 +48,7 @@
     padding-bottom: 30px;
     padding-top: 24px;
   }
-
-  #toboTokenPreview iframe {
+  #toboTokenPreview .toboMint {
     width: 85%;
   }
 

--- a/src/hooks/useProject.ts
+++ b/src/hooks/useProject.ts
@@ -33,12 +33,9 @@ const projectQuery = (id: string) => `
       }
       minterConfiguration {
         basePrice
-        startPrice
         priceIsConfigured
         currencySymbol
         currencyAddress
-        startTime
-        endTime
       }
     }
   }`;

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -47,12 +47,9 @@ const projectsQuery = ({ first, skip, orderDirection }: ProjectsQueryParams) => 
       }
       minterConfiguration {
         basePrice
-        startPrice
         priceIsConfigured
         currencySymbol
         currencyAddress
-        startTime
-        endTime
       }
     }
   }`;

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,13 @@ code {
 a {
   text-decoration: none;
 }
+
+h3.masthead {
+  padding:20px;
+  background-color: #fff;
+  font-size:250% !important;
+}
+
+#toboTokenPreview h4 {
+  padding-left:40px;
+}


### PR DESCRIPTION
- removed routes for project/{projectId} in favor of / root path
- removed Turnout for Burnout masthead in favor of The Colors that Heal header
- added about page for Turnout for Burnout information
- adjusted header layout for title and connect button
- made sure connect button is always visible in header
- removed "the colors that heal" text from the body of the layouts in favor of the header text
- using cross-env library in npm start for windows dev environment compatiability
- modified project query to artblocks api to address obsolete fields.