### PR TITLE
support two types of token paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
         <Routes>
           <Route index element={<ProjectPage />} />
           <Route path="token/:id" element={<TokenPage />} />
+          <Route path="token/:contract/:id" element={<TokenPage />} />
           <Route path="about" element={<HomePage />} />
         </Routes>
       </Router>

--- a/src/components/pages/TokenPage.tsx
+++ b/src/components/pages/TokenPage.tsx
@@ -5,14 +5,19 @@ import { useParams } from 'react-router-dom';
 import TOBOToken from 'components/tobo/TOBOToken';
 
 const TokenPage = () => {
-  const { id } = useParams();
+  const { contract,id } = useParams();
+  let nid = id;
+  if(contract)
+  {
+    nid = contract+id;
+  }
 
   return (
     <TOBOPage>
       {/* {
         id && <TokenDetails id={id} />
       } */}
-      <TOBOToken id={id} />
+      <TOBOToken id={nid} />
     </TOBOPage>
   )
 }


### PR DESCRIPTION
the artbot on block talk was using a slightly different token path from the site. added a route to support both